### PR TITLE
add Vex Snippet Library to menus

### DIFF
--- a/MainMenuCommon.xml
+++ b/MainMenuCommon.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Add Vex Snippet Library to Main Menu Bar/Window -->
+<mainMenu>
+  <menuBar>
+    <subMenu id="windows_menu">
+      <scriptItem id="VexSnippetLibrary">
+        <label>Vex Snippet Library</label>
+        <insertBefore>windows_menu_sep_2</insertBefore>
+        <scriptCode><![CDATA[
+hou.ui.curDesktop().createFloatingPanel(hou.paneTabType.PythonPanel, python_panel_interface="VexSnippetLibrary")
+]]>
+        </scriptCode>
+      </scriptItem>
+    </subMenu>
+  </menuBar>
+</mainMenu>

--- a/PaneTabTypeMenu.xml
+++ b/PaneTabTypeMenu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Add Vex Snippet Library to the Misc section of the pane tab type menu -->
+<menu>
+  <subMenu id="panetype_misc">
+    <actionItem id="pythonpanel::VexSnippetLibrary">
+      <label>Vex Snippet Library</label>
+    </actionItem>
+  </subMenu>
+</menu>


### PR DESCRIPTION
Added a couple of `xml` config files that add Vex Snippet Library to the Main Menu's `Window` menu, and the `+` menu for creating new pane tabs. 

<img width="606" alt="image" src="https://user-images.githubusercontent.com/32847792/149879994-c81199f8-d368-47e2-be3a-2359bb93b961.png">
